### PR TITLE
put quotes around excluded paths with wildcards

### DIFF
--- a/50-borg-local.sh
+++ b/50-borg-local.sh
@@ -20,9 +20,9 @@ $REPOSITORY::'{hostname}-{now:%Y-%m-%d}' \
 /usr/local/sbin \
 /var/lib/dpkg/status \
 /var/lib/dpkg/status-old \
---exclude /home/*/.steam/steam/steamapps/common/ \
---exclude /home/*/.cache \
---exclude /home/*/.mozilla/firefox/*/Cache
+--exclude '/home/*/.steam/steam/steamapps/common/' \
+--exclude '/home/*/.cache' \
+--exclude '/home/*/.mozilla/firefox/*/Cache'
 ) 2>&1)
 if [ $? -ne 0 ] 
   then


### PR DESCRIPTION
after upgrading backupborg to 1.1, we found that we needed to put quotes on excluded paths with * as found in example in issue on order of args: https://github.com/borgbackup/borg/issues/3356